### PR TITLE
writePrefs() doesn't check if prefs file exists before overwriting it

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -625,17 +625,28 @@ Spark.prototype.loadPrefsFile = function(callback) {
 
 Spark.prototype.writePrefs = function() {
   var spark = this;
-  this.prefsEntry.createWriter(function(writer) {
-    writer.truncate(0);
-    writer.onwriteend = function() {
-      var blob = new Blob([spark.ActiveProjectName]);
-      var size = spark.ActiveProjectName.length;
-      writer.write(blob);
-      writer.onwriteend = function() {
-        console.log('prefs file write complete.');
-      };
+  try {
+    var spark = this;
+    var handleOpenPrefs = function(entry) {
+      spark.prefsEntry = entry;
+      entry.file(function(file) {
+        var reader = new FileReader();
+        reader.readAsText(file, 'utf-8');
+      });
     };
-  });
+  } catch FileError.NOT_FOUND_ERR {
+    this.prefsEntry.createWriter(function(writer) {
+      writer.truncate(0);
+      writer.onwriteend = function() {
+        var blob = new Blob([spark.ActiveProjectName]);
+        var size = spark.ActiveProjectName.length;
+        writer.write(blob);
+        writer.onwriteend = function() {
+          console.log('prefs file write complete.');
+        };
+      };
+    });
+  };
 };
 
 Spark.prototype.onSyncFileSystemOpened = function(fs) {


### PR DESCRIPTION
For some reason, writePrefs() seems to indiscriminately create new prefs files instead of checking first to see if the prefs file exists, thus leaving old projects behind in some cases. As a temporary solution, using a try-catch block to see if the file exists first before writing to it is probably the best way to go.
