### PR TITLE
Check if prefs file exists to avoid overwriting it

### DIFF
--- a/spark.js
+++ b/spark.js
@@ -625,17 +625,26 @@ Spark.prototype.loadPrefsFile = function(callback) {
 
 Spark.prototype.writePrefs = function() {
   var spark = this;
-  this.prefsEntry.createWriter(function(writer) {
-    writer.truncate(0);
-    writer.onwriteend = function() {
-      var blob = new Blob([spark.ActiveProjectName]);
-      var size = spark.ActiveProjectName.length;
-      writer.write(blob);
+  try {
+    var checkIfPrefsExists = function(entry) {
+     spark.prefsEntry = entry;
+     entry.file(function(file) {
+       var reader = new FileReader();
+       reader.readAsText(file, 'utf-8');
+      });
+    };
+    checkIfPrefsExists(); 
+  } catch FileError.NOT_FOUND_ERR {
+    this.prefsEntry.createWriter(function(writer) {
+      writer.truncate(0);
       writer.onwriteend = function() {
+        var blob = new Blob([spark.ActiveProjectName]);
+        var size = spark.ActiveProjectName.length;
+        writer.write(blob);
         console.log('prefs file write complete.');
       };
-    };
-  });
+    });
+  };
 };
 
 Spark.prototype.onSyncFileSystemOpened = function(fs) {


### PR DESCRIPTION
Since the Code Editor depends on the prefs file for project listing, if the prefs file is deleted, there are some -- but not all -- cases where un- and reinstallation of the code editor results in well-established projects having files that don't show up in the projects view (very common in the Dev channel). So, as a temporary solution: Don't write to the prefs file if it already exists! Instead, only write the prefs file if a NOT_FOUND_ERROR is caught trying to read it.

Also, there's no need for two duplicate onwriteend handlers, one within another! One is good enough.
