### PR TITLE
Enable scrolling in project list

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -319,6 +319,7 @@ body {
   padding-top: 20px;
   padding-bottom: 10px;
   overflow: scroll;
+  overflow-y: scroll;
 }
 
 .dropdown-menu li {

--- a/css/style.css
+++ b/css/style.css
@@ -318,8 +318,7 @@ body {
   border: solid 1px #cbcbcb;
   padding-top: 20px;
   padding-bottom: 10px;
-  overflow: scroll;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .dropdown-menu li {

--- a/css/style.css
+++ b/css/style.css
@@ -318,6 +318,7 @@ body {
   border: solid 1px #cbcbcb;
   padding-top: 20px;
   padding-bottom: 10px;
+  overflow: scroll;
 }
 
 .dropdown-menu li {


### PR DESCRIPTION
Currently, if the list of projects is larger than the window height, the user can't scroll to access projects that lie below the window bounds. These two changes to the CSS should fix that...
